### PR TITLE
feat(node): cache tool registry

### DIFF
--- a/node/src/node/crew.py
+++ b/node/src/node/crew.py
@@ -5,6 +5,9 @@ from crewai.project import CrewBase, agent, crew, task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from node.tools import custom_tools as ct
 
+# Initialize tool registry once at import time
+TOOL_REGISTRY = ct.get_tool_functions()
+
 # IMPORTANT: use package import (requires src/node/tools/__init__.py to exist)
 
 @CrewBase
@@ -17,12 +20,12 @@ class Node:
     def toolset(self):
         # Print where we loaded the registry from + its keys
         print("[DEBUG] using custom_tools from:", ct.__file__)
-        return ct.get_tool_functions()
+        return TOOL_REGISTRY
 
     @property
     def tool_functions(self):
         # Back-compat for older CrewAI code-paths
-        return self.toolset()
+        return TOOL_REGISTRY
 
     # ---- optional: validate agent tool names early (very helpful) ----
     def _validate_agent_tools(self):


### PR DESCRIPTION
## Summary
- cache custom tool registry once when importing node crew
- use cached registry for toolset and legacy tool_functions property

## Testing
- `uv run pytest` *(fails: tests/memory/test_external_memory.py, tests/rag/qdrant/test_client.py, tests/storage/test_mem0_storage.py)*
- `PYTHONPATH=node/src OPENAI_API_KEY=dummy OPENAI_API_BASE=http://localhost uv run python - <<'PY' ...` *(KeyError: 'ESM Migration Tool')*


------
https://chatgpt.com/codex/tasks/task_e_68bb34a35d688333905ea091d51dc635