### PR TITLE
Fix tool registration for Node Code Analyzer

### DIFF
--- a/node/src/node/config/agents.yaml
+++ b/node/src/node/config/agents.yaml
@@ -7,7 +7,7 @@ code_analyst:
   verbose: true
   allow_delegation: false
   tools:
-    - "Node Code Analyzer"
+    - node_code_analyzer
 
 modernization_specialist:
   role: "Modernization Specialist"
@@ -17,8 +17,8 @@ modernization_specialist:
   verbose: true
   allow_delegation: false
   tools:
-    - "ESM Migration Tool"
-    - "Node Version Migrator"
+    - esm_migration_tool
+    - node_version_migrator
     
 dependency_manager:
   role: Dependency Manager
@@ -27,7 +27,7 @@ dependency_manager:
   verbose: true
   allow_delegation: false
   tools:
-    - Dependency Analyzer
+    - dependency_analyzer
 
 testing_engineer:
   role: Testing Engineer
@@ -36,7 +36,7 @@ testing_engineer:
   verbose: true
   allow_delegation: false
   tools:
-    - Test Generator
+    - test_generator
 
 security_auditor:
   role: Security Auditor
@@ -45,7 +45,7 @@ security_auditor:
   verbose: true
   allow_delegation: false
   tools:
-    - Security Scanner
+    - security_scanner
 
 build_config_specialist:
   role: Build Config Specialist
@@ -54,7 +54,7 @@ build_config_specialist:
   verbose: true
   allow_delegation: false
   tools:
-    - Native Module Migrator
+    - native_module_migrator
 
 performance_optimizer:
   role: Performance Optimizer
@@ -63,4 +63,4 @@ performance_optimizer:
   verbose: true
   allow_delegation: false
   tools:
-    - Watchdog Service Analyzer
+    - watchdog_service_analyzer

--- a/node/src/node/crew.py
+++ b/node/src/node/crew.py
@@ -1,7 +1,7 @@
 from typing import List
 from difflib import get_close_matches
 from crewai import Agent, Crew, Process, Task
-from crewai.project import CrewBase, agent, crew, task
+from crewai.project import CrewBase, agent, crew, task, tool
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from node.tools import custom_tools as ct
 
@@ -23,6 +23,48 @@ class Node:
     def tool_functions(self):
         # Back-compat for older CrewAI code-paths
         return self.toolset()
+
+    # ---- CrewAI tool registration ----
+
+    @tool
+    def node_code_analyzer(self):
+        """Run static analysis on Node.js source"""
+        return self.toolset()["Node Code Analyzer"]()
+
+    @tool
+    def dependency_analyzer(self):
+        """Inspect npm dependencies for issues"""
+        return self.toolset()["Dependency Analyzer"]()
+
+    @tool
+    def watchdog_service_analyzer(self):
+        """Profile the watchdog service"""
+        return self.toolset()["Watchdog Service Analyzer"]()
+
+    @tool
+    def security_scanner(self):
+        """Scan for security vulnerabilities"""
+        return self.toolset()["Security Scanner"]()
+
+    @tool
+    def test_generator(self):
+        """Generate unit tests"""
+        return self.toolset()["Test Generator"]()
+
+    @tool
+    def node_version_migrator(self):
+        """Assist in upgrading Node.js versions"""
+        return self.toolset()["Node Version Migrator"]()
+
+    @tool
+    def esm_migration_tool(self):
+        """Convert CommonJS modules to ESM"""
+        return self.toolset()["ESM Migration Tool"]()
+
+    @tool
+    def native_module_migrator(self):
+        """Handle migration of native modules"""
+        return self.toolset()["Native Module Migrator"]()
 
     # ---- optional: validate agent tool names early (very helpful) ----
     def _validate_agent_tools(self):

--- a/node/src/node/tools/custom_tools.py
+++ b/node/src/node/tools/custom_tools.py
@@ -1,6 +1,9 @@
 # src/node/tools/custom_tools.py
 from typing import Callable, Dict
 
+from crewai.tools import BaseTool
+from pydantic import BaseModel
+
 # import tool classes from the singular file in the same package
 from .custom_tool import (
     NodeCodeAnalyzer,
@@ -15,12 +18,28 @@ from .custom_tool import (
 try:
     from .esm_migration_tool import ESMMigrationTool
 except Exception:
-    ESMMigrationTool = None
+    class _ESMDummy(BaseTool):
+        name: str = "ESM Migration Tool"
+        description: str = "Placeholder ESM migration tool"
+        args_schema: type[BaseModel] = type("ESMStubArgs", (BaseModel,), {})
+
+        def _run(self, *args, **kwargs):
+            return {"error": "ESM Migration Tool not available"}
+
+    ESMMigrationTool = _ESMDummy
 
 try:
     from .native_module_migrator import NativeModuleMigrator
 except Exception:
-    NativeModuleMigrator = None
+    class _NativeDummy(BaseTool):
+        name: str = "Native Module Migrator"
+        description: str = "Placeholder native module migrator"
+        args_schema: type[BaseModel] = type("NativeStubArgs", (BaseModel,), {})
+
+        def _run(self, *args, **kwargs):
+            return {"error": "Native Module Migrator not available"}
+
+    NativeModuleMigrator = _NativeDummy
 
 
 def _ctor(cls):


### PR DESCRIPTION
## Summary
- Register custom Node tools with @tool decorators and update agent config to reference them
- Provide fallback tool stubs when optional dependencies are missing

## Testing
- `OPENAI_API_KEY=dummy PYTHONPATH=node/src python - <<'PY'
from node.tools import custom_tools
from crewai import Agent, Crew, Task

registry = custom_tools.get_tool_functions()
agent = Agent(role='demo', goal='test', backstory='test', tools=[registry['Node Code Analyzer']()])
task = Task(description='use tool', expected_output='done', agent=agent)
crew = Crew(agents=[agent], tasks=[task], process='sequential')
print('crew tool:', crew.agents[0].tools[0].name)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bb3c0e4d3083339fc8727a2343298f