### PR TITLE
Fix custom tool registration and agent tool naming

### DIFF
--- a/node/src/node/config/agents.yaml
+++ b/node/src/node/config/agents.yaml
@@ -7,7 +7,7 @@ code_analyst:
   verbose: true
   allow_delegation: false
   tools:
-    - "Node Code Analyzer"
+    - node_code_analyzer
 
 modernization_specialist:
   role: "Modernization Specialist"
@@ -17,8 +17,8 @@ modernization_specialist:
   verbose: true
   allow_delegation: false
   tools:
-    - "ESM Migration Tool"
-    - "Node Version Migrator"
+    - esm_migration_tool
+    - node_version_migrator
     
 dependency_manager:
   role: Dependency Manager
@@ -27,7 +27,7 @@ dependency_manager:
   verbose: true
   allow_delegation: false
   tools:
-    - Dependency Analyzer
+    - dependency_analyzer
 
 testing_engineer:
   role: Testing Engineer
@@ -36,7 +36,7 @@ testing_engineer:
   verbose: true
   allow_delegation: false
   tools:
-    - Test Generator
+    - test_generator
 
 security_auditor:
   role: Security Auditor
@@ -45,7 +45,7 @@ security_auditor:
   verbose: true
   allow_delegation: false
   tools:
-    - Security Scanner
+    - security_scanner
 
 build_config_specialist:
   role: Build Config Specialist
@@ -54,7 +54,7 @@ build_config_specialist:
   verbose: true
   allow_delegation: false
   tools:
-    - Native Module Migrator
+    - native_module_migrator
 
 performance_optimizer:
   role: Performance Optimizer
@@ -63,4 +63,4 @@ performance_optimizer:
   verbose: true
   allow_delegation: false
   tools:
-    - Watchdog Service Analyzer
+    - watchdog_service_analyzer

--- a/node/src/node/crew.py
+++ b/node/src/node/crew.py
@@ -1,7 +1,7 @@
 from typing import List
 from difflib import get_close_matches
 from crewai import Agent, Crew, Process, Task
-from crewai.project import CrewBase, agent, crew, task
+from crewai.project import CrewBase, agent, crew, task, tool
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from node.tools import custom_tools as ct
 
@@ -15,18 +15,13 @@ class Node:
     tasks: List[Task]
 
     def toolset(self):
-        # Print where we loaded the registry from + its keys
+        """Return mapping of friendly tool names to constructors."""
         print("[DEBUG] using custom_tools from:", ct.__file__)
         return ct.get_tool_functions()
 
-    @property
-    def tool_functions(self):
-        # Back-compat for older CrewAI code-paths
-        return self.toolset()
-
     # ---- optional: validate agent tool names early (very helpful) ----
     def _validate_agent_tools(self):
-        reg = self.toolset()
+        reg = self._filter_functions(self._get_all_functions(), "is_tool")
         reg_keys = set(reg.keys())
         missing = {}
         for agent_name, cfg in self.agents_config.items():
@@ -45,6 +40,39 @@ class Node:
                         print(f"  - {agent}: {bad!r}  (no close match)")
             # Raise a clean error before CrewAI deep-inits agents
             raise RuntimeError("Unregistered tools found in agents.yaml (see [VALIDATION] above)")
+
+    # --- Tool wrappers exposed to CrewAI ---
+    @tool
+    def node_code_analyzer(self):
+        return self.toolset()["Node Code Analyzer"]()
+
+    @tool
+    def dependency_analyzer(self):
+        return self.toolset()["Dependency Analyzer"]()
+
+    @tool
+    def watchdog_service_analyzer(self):
+        return self.toolset()["Watchdog Service Analyzer"]()
+
+    @tool
+    def security_scanner(self):
+        return self.toolset()["Security Scanner"]()
+
+    @tool
+    def test_generator(self):
+        return self.toolset()["Test Generator"]()
+
+    @tool
+    def node_version_migrator(self):
+        return self.toolset()["Node Version Migrator"]()
+
+    @tool
+    def esm_migration_tool(self):
+        return self.toolset()["ESM Migration Tool"]()
+
+    @tool
+    def native_module_migrator(self):
+        return self.toolset()["Native Module Migrator"]()
 
     @agent
     def researcher(self) -> Agent:

--- a/node/src/node/tools/custom_tools.py
+++ b/node/src/node/tools/custom_tools.py
@@ -15,12 +15,22 @@ from .custom_tool import (
 try:
     from .esm_migration_tool import ESMMigrationTool
 except Exception:
-    ESMMigrationTool = None
+    from crewai.tools import BaseTool
+    class ESMMigrationTool(BaseTool):
+        name: str = "ESM Migration Tool"
+        description: str = "Placeholder tool: real implementation unavailable"
+        def _run(self, *args, **kwargs):  # type: ignore[override]
+            return {"error": "ESM Migration Tool not installed"}
 
 try:
     from .native_module_migrator import NativeModuleMigrator
 except Exception:
-    NativeModuleMigrator = None
+    from crewai.tools import BaseTool
+    class NativeModuleMigrator(BaseTool):
+        name: str = "Native Module Migrator"
+        description: str = "Placeholder tool: real implementation unavailable"
+        def _run(self, *args, **kwargs):  # type: ignore[override]
+            return {"error": "Native Module Migrator not installed"}
 
 
 def _ctor(cls):


### PR DESCRIPTION
## Summary
- expose all custom tools via `@tool` wrappers in crew
- add placeholder implementations for optional migration tools
- align agent config with tool method names

## Testing
- `PYTHONPATH=node/src python - <<'PY'
from node.crew import Node
n = object.__new__(Node)
print(isinstance(n.node_code_analyzer(), object))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bb3c0e4d3083339fc8727a2343298f